### PR TITLE
Fix error handler forwarding into request object

### DIFF
--- a/src/SendiosSdk.php
+++ b/src/SendiosSdk.php
@@ -55,7 +55,7 @@ class SendiosSdk
      * @param string $clientKey
      * @throws Exception\EncryptException
      */
-    public function __construct(int $clientId, string $clientKey)
+    public function __construct(int $clientId, string $clientKey, ErrorHandler $errorHandler = null)
     {
         if (empty($clientId)) {
             throw new \InvalidArgumentException('clientId cannot be empty');
@@ -67,7 +67,7 @@ class SendiosSdk
         $this->clientId = $clientId;
         $this->clientKey = $clientKey;
 
-        $this->errorHandler = new ErrorHandler();
+        $this->errorHandler = $errorHandler ?? new ErrorHandler();
         $this->encrypter = $this->getEncrypter($this->clientKey);
         $this->request = new Request($this->clientId, $this->clientKey, $this->errorHandler);
     }

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sendios\SendiosSdk;
+use Sendios\Services\CurlRequest;
+use Sendios\Services\ErrorHandler;
+
+final class ErrorHandlerTest extends TestCase
+{
+    public function testErrorHandler(): void
+    {
+        $customErrorHandler = $this->createMock(ErrorHandler::class);
+        $customErrorHandler->expects($this->once())->method('handle');
+
+        $curlRequest = $this->createMock(CurlRequest::class);
+        $curlRequest->expects($this->once())
+            ->method('execute')
+            ->willReturn(false);
+        $curlRequest->expects($this->once())
+            ->method('getInfo')
+            ->willReturn(500);
+
+        $sdk = new SendiosSdk(123, 'a1s2d3f4g5h6j7k8l', $customErrorHandler);
+        $sdk->request->setCurlRequest($curlRequest);
+
+        $sdk->email->validate(1, 'test@validate.email');
+    }
+}


### PR DESCRIPTION
в первоначальной реализации если нужно переопределить error handler, то он не пробрасывается в объект request и приходится полностью пересоздавать этот объект, что бы он мог использовать кастомный error handler